### PR TITLE
remove aliases, add join parsing

### DIFF
--- a/queryParser.js
+++ b/queryParser.js
@@ -1,11 +1,26 @@
-function parseSQLGetQuery(table, query, aliases) {
+function parseSQLGetQuery(table, query) {
+    let FROM_clause = `FROM ${table}`;
+    const join = query["JOIN"];
+    if (join) {
+        const joinFields = join.replace(/[\[\]]/g, "").split(",");
+        const fromFields = [table];
+        for (let i = 0; i < joinFields.length; i++) {
+            let curr = joinFields[i];
+            let index = 2;
+            while (fromFields.includes(curr)) {
+                curr = `${joinFields[i]} ${joinFields[i]}${index}`
+                index++;
+            }
+            fromFields.push(curr);
+        }
+        FROM_clause =`FROM ${fromFields.join(", ")}`;
+    }
+    delete query["JOIN"];
+
     let SELECT_clause = "SELECT *";
     const select = query["SELECT"];
     if (select) {
-        const queryFields = select.replace(/[\[\]]/g, "").split(",");
-        const selectFields = queryFields.map((field) => {
-            return aliases[field] || field;
-        })
+        const selectFields = select.replace(/[\[\]]/g, "");
         SELECT_clause = `SELECT ${selectFields}`;
     }
     delete query["SELECT"];
@@ -15,12 +30,12 @@ function parseSQLGetQuery(table, query, aliases) {
     if (queryEntries.length !== 0) {
         WHERE_clause = " WHERE ";
         for (const [field, value] of queryEntries) {
-            WHERE_clause += `AND ${aliases[field] || field} = ${value} `
+            WHERE_clause += `AND ${field} = ${value} `
         } 
         WHERE_clause = WHERE_clause.replace("AND ", "");
     }
 
-    return `${SELECT_clause} FROM ${table}${WHERE_clause}`;
+    return `${SELECT_clause} ${FROM_clause}${WHERE_clause}`;
 }
 
 function parseSQLPostQuery(table, body, orderedFields) {
@@ -31,7 +46,12 @@ function parseSQLPostQuery(table, body, orderedFields) {
     return `INSERT INTO ${table} VALUES (${values})`;
 }
 
+function queryHasJoinParam(query) {
+    return query["JOIN"] ? true : false;
+}
+
 module.exports = {
     parseSQLGetQuery,
-    parseSQLPostQuery
+    parseSQLPostQuery,
+    queryHasJoinParam
 }

--- a/routes/agents.js
+++ b/routes/agents.js
@@ -5,16 +5,11 @@ var queryParser = require('../queryParser');
 
 /* GET agents table */
 router.get('/', function(req, res, next) {
-    const SQL_command = queryParser.parseSQLGetQuery("Agent", req.query, {});
-    connection.query(SQL_command, function (err, results, fields) {
+    const hasJoin =  queryParser.queryHasJoinParam(req.query);
+    const cmd = queryParser.parseSQLGetQuery("Agent", req.query, {});
+    connection.query({ sql: cmd, nestTables: hasJoin ? "_" : false }, function (err, results, fields) {
         if (err) throw err;
-        response = results.map(r => {
-            return {
-                'name': r.name,
-                'type': r.type
-            };
-        });
-        res.json(response);
+        res.json(results);
     })
 });
 

--- a/routes/players.js
+++ b/routes/players.js
@@ -5,21 +5,11 @@ var queryParser = require('../queryParser');
 
 /* GET players table */
 router.get('/', function(req, res, next) {
-    const aliases = { name: "player_id", rank: "p_rank" };
-    const SQL_GET_command = queryParser.parseSQLGetQuery("Player", req.query, aliases);
-    connection.query(SQL_GET_command, function (err, results, fields) {
+    const hasJoin =  queryParser.queryHasJoinParam(req.query);
+    const cmd = queryParser.parseSQLGetQuery("Player", req.query);
+    connection.query({ sql: cmd, nestTables: hasJoin ? "_" : false }, function (err, results, fields) {
         if (err) res.err(err);
-        response = results.map(r => {
-            return {
-                'name': r.player_id,
-                'rank': r.p_rank,
-                'kills': r.kills,
-                'assists': r.assists,
-                'deaths': r.deaths,
-                'headshot_percentage': r.headshot_percentage
-            };
-        });
-        res.json(response);
+        res.json(results);
     })
 });
 


### PR DESCRIPTION
Can now specify additional tables to join with JOIN query param (JOIN is an array of table names)

ex. http://localhost:3001/agents?JOIN=[Agent]&SELECT=[Agent2.name,Agent.name]&Agent2.name=Agent.name
Will join Agent with Agent, and use aliases Agent, Agent2, (and then Agent3, Agent4... etc)

ex. http://localhost:3001/agents?JOIN=[Player]&SELECT=[name,p_rank]
Will join Agent with Player, and use aliases Agent, Player

modified connection.query call to get back nested table names when joining tables

remove db field aliases